### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/DaMichel/Fuselage/Fuselage.version
+++ b/GameData/DaMichel/Fuselage/Fuselage.version
@@ -1,6 +1,6 @@
 {
 	"NAME":"DaMichel's Fuselage",
-	"URL":"https://github.com/zer0Kerbal/DaMichel/raw/GameData/DaMichel/Fuselage/Fuselage.version",
+	"URL":"https://raw.githubusercontent.com/zer0Kerbal/DaMichel/master/GameData/DaMichel/Fuselage/Fuselage.version",
 	"DOWNLOAD":"https://github.com/zer0Kerbal/DaMichel/releases",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/DaMichel/GameData/DaMichel/Fuselage/Changelog.cfg",
     "GITHUB":


### PR DESCRIPTION
The version file's URL property was invalid.
Now it's fixed.